### PR TITLE
Sutton sc 1535 add ability for services to be tagged with

### DIFF
--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -184,11 +184,6 @@ export default {
 
       this.loading = false;
     },
-    async fetchCollections() {
-      this.loading = true;
-      const { data } = await http.get("/collections/categories/all");
-      this.loading = data.data;
-    },
     parsePages(pages, parsed = [], depth = 0) {
       pages
         .filter(page => !this.page || page.id !== this.page.id)

--- a/src/views/services/Create.vue
+++ b/src/views/services/Create.vue
@@ -80,6 +80,7 @@
                 @update:logo_file_id="form.logo_file_id = $event"
                 :status.sync="form.status"
                 :gallery_items.sync="form.gallery_items"
+                :tags.sync="form.tags"
               >
                 <gov-button @click="onNext" start>Next</gov-button>
               </details-tab>
@@ -258,6 +259,7 @@ export default {
         ],
         offerings: [],
         gallery_items: [],
+        tags: [],
         category_taxonomies: [],
         eligibility_types: {
           taxonomies: [],

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -53,6 +53,7 @@
                   @update:logo="form.logo = $event"
                   :status.sync="form.status"
                   :gallery_items.sync="form.gallery_items"
+                  :tags.sync="form.tags"
                   :id="service.id"
                 >
                   <gov-button @click="onNext" start>Next</gov-button>
@@ -316,6 +317,7 @@ export default {
           file_id: galleryItem.file_id,
           image: null
         })),
+        tags: this.service.tags,
         category_taxonomies: this.service.category_taxonomies.map(
           taxonomy => taxonomy.id
         ),

--- a/src/views/services/forms/DetailsTab.vue
+++ b/src/views/services/forms/DetailsTab.vue
@@ -139,6 +139,17 @@
           :errors="errors"
         />
 
+        <gov-heading size="m">Tags</gov-heading>
+
+        <gov-body> Select tags to help users find the {{ type }}. </gov-body>
+
+        <tag-input
+          :service-tags="tags"
+          @input="$emit('update:tags', $event)"
+          @clear="$emit('clear', $event)"
+          :errors="errors"
+        />
+
         <slot />
       </gov-grid-column>
     </gov-grid-row>
@@ -148,10 +159,11 @@
 <script>
 import CkImageInput from "@/components/Ck/CkImageInput";
 import CkGalleryItemsInput from "@/views/services/inputs/GalleryItemsInput";
+import TagInput from "@/views/services/inputs/TagInput";
 
 export default {
   name: "DetailsTab",
-  components: { CkImageInput, CkGalleryItemsInput },
+  components: { CkImageInput, CkGalleryItemsInput, TagInput },
   props: {
     errors: {
       required: true
@@ -180,6 +192,9 @@ export default {
       required: true
     },
     gallery_items: {
+      required: true
+    },
+    tags: {
       required: true
     },
     id: {

--- a/src/views/services/inputs/TagInput.vue
+++ b/src/views/services/inputs/TagInput.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <div v-if="auth.isGlobalAdmin">
+      <gov-checkboxes>
+        <gov-checkbox
+          v-for="tag in combinedTags"
+          :key="tag.slug"
+          :id="tag.slug"
+          :value="serviceTagSlugs.includes(tag.slug)"
+          :name="tag.slug"
+          :label="tag.label"
+          @input="updateTags({ tag, enabled: $event })"
+        />
+      </gov-checkboxes>
+      <gov-form-group>
+        <ck-text-input
+          id="new-tag"
+          v-model="newTag.label"
+          label="Create new tag"
+          :error="newTagError"
+        />
+        <gov-button type="button" @click="updateTags({ tag: newTag })">
+          Add tag
+        </gov-button>
+      </gov-form-group>
+    </div>
+    <gov-tag v-else v-for="serviceTag in serviceTags" :key="serviceTag.slug">
+      {{ serviceTag.label }}
+    </gov-tag>
+  </div>
+</template>
+
+<script>
+import http from "@/http";
+import CkTextInput from "@/components/Ck/CkTextInput";
+
+export default {
+  components: { CkTextInput },
+  name: "TagInput",
+
+  props: {
+    serviceTags: {
+      type: Array,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      tags: [],
+      newTag: {
+        label: ""
+      },
+      newTagError: null
+    };
+  },
+
+  computed: {
+    serviceTagSlugs() {
+      return this.serviceTags.map(tag => tag.slug);
+    },
+    combinedTags() {
+      const tagSlugs = this.tags.map(tag => tag.slug);
+      const newTags = this.serviceTags.filter(
+        tag => !tagSlugs.includes(tag.slug)
+      );
+      return this.tags.concat(newTags);
+    }
+  },
+
+  methods: {
+    async fetchTags() {
+      this.loading = true;
+      const { data } = await http.get("/tags");
+      this.tags = data.data;
+      this.loading = false;
+    },
+    updateTags(update) {
+      let serviceTags = this.serviceTags.slice();
+      if (update.enabled === false) {
+        serviceTags = this.serviceTags.filter(
+          tag => tag.slug !== update.tag.slug
+        );
+      } else {
+        // If this is a new tag, check if it exists
+        if (
+          !update.tag.id &&
+          this.combinedTags.filter(
+            tag => tag.slug === this.slugify(update.tag.label)
+          ).length
+        ) {
+          this.newTagError = `Tag ${update.tag.label} already exists`;
+          this.newTag = { label: "" };
+          return;
+        }
+        serviceTags.push({
+          slug: this.slugify(update.tag.label),
+          label: update.tag.label
+        });
+        this.newTag = { label: "" };
+      }
+      this.$emit("input", serviceTags);
+    }
+  },
+
+  created() {
+    this.fetchTags();
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/services/show/DetailsTab.vue
+++ b/src/views/services/show/DetailsTab.vue
@@ -78,6 +78,20 @@
             <gov-body v-else>-</gov-body>
           </gov-table-cell>
         </gov-table-row>
+        <gov-table-row>
+          <gov-table-header top scope="row">Tags</gov-table-header>
+          <gov-table-cell>
+            <gov-list v-if="service.tags.length > 0" bullet>
+              <li
+                v-for="(tag, index) in service.tags"
+                :key="`ServiceTag::${index}`"
+              >
+                {{ tag.label }}
+              </li>
+            </gov-list>
+            <template v-else>None</template>
+          </gov-table-cell>
+        </gov-table-row>
       </template>
     </gov-table>
   </div>

--- a/src/views/update-requests/show/ServiceDetails.vue
+++ b/src/views/update-requests/show/ServiceDetails.vue
@@ -376,6 +376,37 @@
           }}</gov-table-cell>
         </gov-table-row>
 
+        <gov-table-row v-if="service.hasOwnProperty('tags')">
+          <gov-table-header top scope="row">Tags</gov-table-header>
+          <gov-table-cell v-if="original">
+            <gov-list
+              v-if="
+                original.hasOwnProperty('tags') && Array.isArray(original.tags)
+              "
+              bullet
+            >
+              <li
+                v-for="(tag, index) in original.tags"
+                :key="`ServiceTag::Original::${index}`"
+              >
+                {{ tag.label }}
+              </li>
+            </gov-list>
+            <template v-else>None</template>
+          </gov-table-cell>
+          <gov-table-cell>
+            <gov-list v-if="Array.isArray(service.tags)" bullet>
+              <li
+                v-for="(tag, index) in service.tags"
+                :key="`ServiceTag::New::${index}`"
+              >
+                {{ tag.label }}
+              </li>
+            </gov-list>
+            <template v-else>None</template>
+          </gov-table-cell>
+        </gov-table-row>
+
         <gov-table-row v-if="service.hasOwnProperty('category_taxonomies')">
           <gov-table-header top scope="row"
             >Category taxonomies</gov-table-header


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1535/add-ability-for-services-to-be-tagged-with-business-unit-labels

Added UI to allow tags to be created on the fly and attached to services

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
