### PR TITLE
Added ordering to page content sections

### DIFF
--- a/src/components/CkPageContent.vue
+++ b/src/components/CkPageContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-for="(section, sectionId) in content" :key="sectionId">
+    <div v-for="[sectionId, section] in sortedContent" :key="sectionId">
       <gov-heading tag="h3" size="m">{{ section.label }}</gov-heading>
       <ck-text-input
         v-if="Object.keys(section).includes('title')"
@@ -38,6 +38,32 @@ export default {
     },
     errors: {
       required: true
+    }
+  },
+
+  data() {
+    return {
+      contentOrder: {
+        introduction: 1,
+        about: 2,
+        info_pages: 3,
+        collections: 4
+      }
+    };
+  },
+
+  computed: {
+    sortedContent() {
+      return Object.entries(this.content)
+        .map(([key, value]) => {
+          if (!value.order) {
+            value.order = this.contentOrder[key];
+          }
+          return [key, value];
+        })
+        .sort((a, b) => {
+          return a[1].order - b[1].order;
+        });
     }
   },
 

--- a/src/views/pages/Create.vue
+++ b/src/views/pages/Create.vue
@@ -60,22 +60,26 @@ export default {
       contentTypes: {
         landing: {
           introduction: {
+            order: 1,
             label: "Introduction",
             hint: "",
             copy: [""]
           },
           about: {
+            order: 2,
             label: "About",
             hint: "",
             copy: ["", ""]
           },
           info_pages: {
+            order: 3,
             label: "Information Pages",
             hint: "",
             title: "",
             copy: [""]
           },
           collections: {
+            order: 4,
             label: "Collections",
             hint: "",
             title: "",
@@ -84,6 +88,7 @@ export default {
         },
         information: {
           introduction: {
+            order: 1,
             label: "Page content",
             hint:
               "This is the largest content of the page. Use formatting to improve readability and impact.",


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1862/admin-ui-pages-field-order-is-different-between-add-and-edit-page

Added ordering to page content sections

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
