### PR TITLE
Sutton sc 1933 when editing a landing info page with an

### DIFF
--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -107,12 +107,14 @@ export default {
           delete data.enabled
         }
 
-        // Remove the image from the request if null, or delete if false.
-        if (
-          data.image_file_id === null ||
-          (this.page.image && data.image_file_id === this.page.image.id)
-        ) {
+        // Remove the image from the request if unchanged.
+        if (this.page.image && data.image_file_id === this.page.image.id) {
           delete data.image_file_id
+        }
+
+        // Convert false to null if removed
+        if (data.image_file_id === false) {
+          data.image_file_id = null
         }
 
         if (

--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -108,15 +108,11 @@ export default {
         }
 
         // Remove the image from the request if null, or delete if false.
-        if (data.image_file_id === null) {
-          delete data.image_file_id
-        } else if (
-          this.page.image &&
-          data.image_file_id === this.page.image.id
+        if (
+          data.image_file_id === null ||
+          (this.page.image && data.image_file_id === this.page.image.id)
         ) {
           delete data.image_file_id
-        } else if (data.image_file_id === false) {
-          data.image_file_id = null
         }
 
         if (


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/1933/when-editing-a-landing-info-page-with-an-existing-image-updating-the-content-and-saving-deletes-the-existing-image

- Refactored Pages/Edit to only pass image_file_id if it has changed
- Passes a file id if changed to another image
- Passes null if the image is removed 

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
