### PR TITLE
Added admin facility for page excerpts

### DIFF
--- a/src/views/pages/Create.vue
+++ b/src/views/pages/Create.vue
@@ -9,6 +9,7 @@
         :page_type.sync="form.page_type"
         :parent_id.sync="form.parent_id"
         :title.sync="form.title"
+        :excerpt.sync="form.excerpt"
         :content.sync="form.content"
         :image_file_id.sync="form.image_file_id"
         :collections.sync="form.collections"
@@ -50,6 +51,7 @@ export default {
       form: new Form({
         parent_id: null,
         title: '',
+        excerpt: '',
         content: '',
         page_type: this.type,
         image_file_id: null,

--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -14,6 +14,7 @@
           :parent_id.sync="form.parent_id"
           :page_type.sync="form.page_type"
           :title.sync="form.title"
+          :excerpt.sync="form.excerpt"
           :content.sync="form.content"
           :image_file_id.sync="form.image_file_id"
           :collections.sync="form.collections"
@@ -78,6 +79,7 @@ export default {
       this.page = response.data.data
       this.form = new Form({
         title: this.page.title,
+        excerpt: this.page.excerpt,
         content: this.page.content,
         page_type: this.page.page_type,
         parent_id: this.page.parent ? this.page.parent.id : null,
@@ -93,6 +95,9 @@ export default {
         // Remove any unchanged values.
         if (data.title === this.page.title) {
           delete data.title
+        }
+        if (data.excerpt === this.page.excerpt) {
+          delete data.excerpt
         }
         if (data.content === this.page.content) {
           delete data.content

--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -23,6 +23,15 @@
       :error="errors.get('title')"
     />
 
+    <ck-text-input
+      :value="excerpt"
+      @input="onInput('excerpt', $event)"
+      id="excerpt"
+      label="Excerpt"
+      type="text"
+      :error="errors.get('excerpt')"
+    />
+
     <ck-page-content
       :content="content"
       id="content"
@@ -85,6 +94,10 @@ export default {
     title: {
       type: String,
       required: true,
+    },
+    excerpt: {
+      type: String,
+      default: '',
     },
     content: {
       type: Object,


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2140/add-a-new-field-to-information-pages-to-store-an-excerpt

- Added excerpt field to create page
- Added excerpt field to update page

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
