### PR TITLE
Added update in place to page slug field when title is changed

### DIFF
--- a/src/views/pages/Create.vue
+++ b/src/views/pages/Create.vue
@@ -6,6 +6,7 @@
     <gov-main-wrapper>
       <page-form
         :errors="form.$errors"
+        :is-new="true"
         :page_type.sync="form.page_type"
         :parent_id.sync="form.parent_id"
         :title.sync="form.title"

--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -11,6 +11,7 @@
         <page-form
           :page="page"
           :errors="form.$errors"
+          :is-new="false"
           :parent_id.sync="form.parent_id"
           :page_type.sync="form.page_type"
           :title.sync="form.title"

--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -39,7 +39,7 @@
     </ck-text-input>
 
     <ck-text-input
-      :value="excerpt"
+      :value="excerpt || ''"
       @input="onInput('excerpt', $event)"
       id="excerpt"
       label="Excerpt"
@@ -102,6 +102,11 @@ export default {
     errors: {
       type: Object,
       required: true,
+    },
+    isNew: {
+      required: false,
+      type: Boolean,
+      default: false,
     },
     parent_id: {
       required: true,
@@ -207,6 +212,11 @@ export default {
     onInput(field, value) {
       this.$emit(`update:${field}`, value)
       this.$emit('clear', field)
+
+      if (this.auth.isGlobalAdmin && field === 'title' && this.isNew) {
+        this.$emit('update:slug', this.slugify(value))
+        this.$emit('clear', 'slug')
+      }
     },
     async fetchPages() {
       this.loading = true


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2168/auto-generate-slug-from-title-field-when-adding-new-pages

- Added update in place for page slug field when title is changed
- Limited update in place to new pages and only if global admin

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
