### PR TITLE
Sutton sc 2138 update page structure to allow content blocks

### DIFF
--- a/src/components/Ck/CkCallToAction.vue
+++ b/src/components/Ck/CkCallToAction.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <gov-heading tag="h4" size="s">Call to action</gov-heading>
+    <gov-error-message v-if="error !== null" v-text="error" :for="id" />
+    <ck-text-input
+      :value="callToAction.title"
+      @input="onInput('title', $event)"
+      id="cta-title"
+      label="Title"
+      type="text"
+      :error="null"
+    />
+    <ck-textarea-input
+      :value="callToAction.description"
+      @input="onInput('description', $event)"
+      id="cta-description"
+      label="Description"
+      :error="null"
+    />
+    <ck-text-input
+      :value="callToAction.url"
+      @input="onInput('url', $event)"
+      id="cta-url"
+      label="Link address"
+      type="text"
+      :error="null"
+    />
+    <ck-text-input
+      :value="callToAction.buttonText"
+      @input="onInput('buttonText', $event)"
+      id="cta-button-text"
+      label="Button text"
+      type="text"
+      :error="null"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CallToAction',
+
+  props: {
+    callToAction: {
+      type: Object,
+      required: true,
+    },
+    error: {
+      required: true,
+    },
+  },
+
+  methods: {
+    onInput(field, value) {
+      const callToAction = Object.assign({}, this.callToAction)
+      callToAction[field] = value
+      this.$emit('input', callToAction)
+      this.$emit('clear', 'callToAction')
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/CkPageContent.vue
+++ b/src/components/CkPageContent.vue
@@ -34,17 +34,27 @@
           :error="errors.get(`content.${sectionId}.content.${index}`)"
         />
         <gov-button type="button" @click="addCopy(sectionId, index)"
-          >Add Copy</gov-button
+          >Add Copy here</gov-button
         >&nbsp;
         <gov-button type="button" @click="addCallToAction(sectionId, index)"
-          >Add Call to action</gov-button
+          >Add Call to action here</gov-button
         >&nbsp;
+        <span v-if="index > 0">
+          <gov-button
+            type="button"
+            :warning="true"
+            @click="removeContent(sectionId, index)"
+            >Remove Content</gov-button
+          >&nbsp;
+          <gov-button type="button" @click="moveUp(sectionId, index)"
+            >Move up</gov-button
+          >&nbsp;
+        </span>
         <gov-button
-          v-if="index > 0"
+          v-if="index < section.content.length - 1"
           type="button"
-          :warning="true"
-          @click="removeContent(sectionId, index)"
-          >Remove Content</gov-button
+          @click="moveDown(sectionId, index)"
+          >Move down</gov-button
         >
       </div>
     </div>
@@ -151,6 +161,28 @@ export default {
       const content = Object.assign({}, this.content)
 
       content[section]['content'].splice(index, 1)
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_content`)
+    },
+
+    moveUp(section, index) {
+      const content = Object.assign({}, this.content)
+      const contentBlock = Object.assign({}, content[section]['content'][index])
+
+      content[section]['content'].splice(index, 1)
+      content[section]['content'].splice(index - 1, 0, contentBlock)
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_content`)
+    },
+
+    moveDown(section, index) {
+      const content = Object.assign({}, this.content)
+      const contentBlock = Object.assign({}, content[section]['content'][index])
+
+      content[section]['content'].splice(index, 1)
+      content[section]['content'].splice(index + 1, 0, contentBlock)
 
       this.$emit('update', content)
       this.$emit('clear', `content_${section}_content`)

--- a/src/components/CkPageContent.vue
+++ b/src/components/CkPageContent.vue
@@ -5,24 +5,38 @@
       <ck-text-input
         v-if="Object.keys(section).includes('title')"
         :value="section.title"
-        @input="onChange(sectionId, 'title', null, $event)"
+        @input="onChangeTitle(sectionId, $event)"
         :id="`${sectionId}-title`"
         label="Title"
         type="text"
         :error="errors.get(`content_${sectionId}_title`)"
       />
-      <ck-wysiwyg-input
-        v-for="(copy, index) in section.copy"
+      <div
+        v-for="(content, index) in section.content"
         :key="`${sectionId}-copy-${index}`"
-        :value="copy"
-        @input="onChange(sectionId, 'copy', index, $event)"
-        :id="`${sectionId}-copy-${index}`"
-        :label="section.label"
-        :hint="section.hint"
-        :error="errors.get(`content_${sectionId}_copy_${index}`)"
-        large
-        :maxlength="60000"
-      />
+      >
+        <ck-wysiwyg-input
+          v-if="content.type === 'copy'"
+          :value="content.value"
+          @input="onChangeCopy(sectionId, 'copy', index, $event)"
+          :id="`${sectionId}-copy-${index}`"
+          :label="section.label"
+          :hint="section.hint"
+          :error="errors.get(`content_${sectionId}_copy_${index}`)"
+          large
+          :maxlength="60000"
+        />
+        <gov-button type="button" @click="addCopy(sectionId, index)"
+          >Add Content</gov-button
+        >&nbsp;
+        <gov-button
+          v-if="index > 0"
+          type="button"
+          :warning="true"
+          @click="removeCopy(sectionId, index)"
+          >Remove Content</gov-button
+        >
+      </div>
     </div>
   </div>
 </template>
@@ -68,16 +82,43 @@ export default {
   },
 
   methods: {
-    onChange(section, field, index, value) {
+    onChangeTitle(section, value) {
       const content = Object.assign({}, this.content)
 
-      if (null === index) {
-        content[section][field] = value
-      } else {
-        content[section][field][index] = value
-      }
+      content[section]['title'] = value
+
       this.$emit('update', content)
-      this.$emit('clear', `content_${section}_${field}`)
+      this.$emit('clear', `content_${section}_title`)
+    },
+    onChangeCopy(section, index, value) {
+      const content = Object.assign({}, this.content)
+
+      content[section]['content'][index] = {
+        type: 'copy',
+        value: value,
+      }
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_copy`)
+    },
+    addCopy(section, index) {
+      const content = Object.assign({}, this.content)
+
+      content[section]['content'].splice(index + 1, 0, {
+        type: 'copy',
+        value: '',
+      })
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_copy`)
+    },
+    removeCopy(section, index) {
+      const content = Object.assign({}, this.content)
+
+      content[section]['content'].splice(index, 1)
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_copy`)
     },
   },
 }

--- a/src/components/CkPageContent.vue
+++ b/src/components/CkPageContent.vue
@@ -13,27 +13,37 @@
       />
       <div
         v-for="(content, index) in section.content"
-        :key="`${sectionId}-copy-${index}`"
+        :key="`${sectionId}-content-${index}`"
       >
         <ck-wysiwyg-input
           v-if="content.type === 'copy'"
           :value="content.value"
-          @input="onChangeCopy(sectionId, 'copy', index, $event)"
+          @input="onChangeCopy(sectionId, index, $event)"
           :id="`${sectionId}-copy-${index}`"
           :label="section.label"
           :hint="section.hint"
-          :error="errors.get(`content_${sectionId}_copy_${index}`)"
+          :error="errors.get(`content.${sectionId}.content.${index}`)"
           large
           :maxlength="60000"
         />
+        <ck-call-to-action
+          v-else-if="content.type === 'cta'"
+          :call-to-action="content"
+          :id="`${sectionId}-cta-${index}`"
+          @input="onChangeCalltoAction(sectionId, index, $event)"
+          :error="errors.get(`content.${sectionId}.content.${index}`)"
+        />
         <gov-button type="button" @click="addCopy(sectionId, index)"
-          >Add Content</gov-button
+          >Add Copy</gov-button
+        >&nbsp;
+        <gov-button type="button" @click="addCallToAction(sectionId, index)"
+          >Add Call to action</gov-button
         >&nbsp;
         <gov-button
           v-if="index > 0"
           type="button"
           :warning="true"
-          @click="removeCopy(sectionId, index)"
+          @click="removeContent(sectionId, index)"
           >Remove Content</gov-button
         >
       </div>
@@ -42,8 +52,14 @@
 </template>
 
 <script>
+import CkCallToAction from './Ck/CkCallToAction'
+
 export default {
   name: 'PageContent',
+
+  components: {
+    CkCallToAction,
+  },
 
   props: {
     content: {
@@ -93,13 +109,18 @@ export default {
     onChangeCopy(section, index, value) {
       const content = Object.assign({}, this.content)
 
-      content[section]['content'][index] = {
-        type: 'copy',
-        value: value,
-      }
+      content[section]['content'][index].value = value
 
       this.$emit('update', content)
-      this.$emit('clear', `content_${section}_copy`)
+      this.$emit('clear', `content_${section}_content`)
+    },
+    onChangeCalltoAction(section, index, cta) {
+      const content = Object.assign({}, this.content)
+
+      content[section]['content'][index] = cta
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_content`)
     },
     addCopy(section, index) {
       const content = Object.assign({}, this.content)
@@ -110,15 +131,29 @@ export default {
       })
 
       this.$emit('update', content)
-      this.$emit('clear', `content_${section}_copy`)
+      this.$emit('clear', `content_${section}_content`)
     },
-    removeCopy(section, index) {
+    addCallToAction(section, index) {
+      const content = Object.assign({}, this.content)
+
+      content[section]['content'].splice(index + 1, 0, {
+        type: 'cta',
+        title: '',
+        description: '',
+        url: '',
+        buttonText: '',
+      })
+
+      this.$emit('update', content)
+      this.$emit('clear', `content_${section}_content`)
+    },
+    removeContent(section, index) {
       const content = Object.assign({}, this.content)
 
       content[section]['content'].splice(index, 1)
 
       this.$emit('update', content)
-      this.$emit('clear', `content_${section}_copy`)
+      this.$emit('clear', `content_${section}_content`)
     },
   },
 }

--- a/src/views/pages/Create.vue
+++ b/src/views/pages/Create.vue
@@ -68,27 +68,47 @@ export default {
             order: 1,
             label: 'Introduction',
             hint: '',
-            copy: [''],
+            content: [
+              {
+                type: 'copy',
+                value: '',
+              },
+            ],
           },
           about: {
             order: 2,
             label: 'About',
             hint: '',
-            copy: ['', ''],
+            content: [
+              {
+                type: 'copy',
+                value: '',
+              },
+            ],
           },
           info_pages: {
             order: 3,
             label: 'Information Pages',
             hint: '',
             title: '',
-            copy: [''],
+            content: [
+              {
+                type: 'copy',
+                value: '',
+              },
+            ],
           },
           collections: {
             order: 4,
             label: 'Collections',
             hint: '',
             title: '',
-            copy: [''],
+            content: [
+              {
+                type: 'copy',
+                value: '',
+              },
+            ],
           },
         },
         information: {
@@ -97,7 +117,12 @@ export default {
             label: 'Page content',
             hint:
               'This is the largest content of the page. Use formatting to improve readability and impact.',
-            copy: [''],
+            content: [
+              {
+                type: 'copy',
+                value: '',
+              },
+            ],
           },
         },
       },


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2138/update-page-structure-to-allow-content-blocks

- Created admin UI to add call to action blocks
- Updated admin UI to manage mixed block content
- Added functionality to add, remove and move content blocks

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
