### PR TITLE
Hide excerpt field from landing page

### DIFF
--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -39,6 +39,7 @@
     </ck-text-input>
 
     <ck-text-input
+      v-if="page_type === 'information'"
       :value="excerpt || ''"
       @input="onInput('excerpt', $event)"
       id="excerpt"


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2200/remove-excerpt-field-from-landing-pages-in-admin-ui

- Hide excerpt field when page type is landing

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
