### PR TITLE
Sutton sc 2226 service org admins can t update services

### DIFF
--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -439,6 +439,9 @@ export default {
           ) {
             delete data.eligibility_types
           }
+          if (JSON.stringify(data.tags) === JSON.stringify(this.service.tags)) {
+            delete data.tags
+          }
 
           // Remove the logo from the request if null, or delete if false.
           if (data.logo_file_id === null) {

--- a/src/views/services/forms/DetailsTab.vue
+++ b/src/views/services/forms/DetailsTab.vue
@@ -141,7 +141,9 @@
 
         <gov-heading size="m">Tags</gov-heading>
 
-        <gov-body> Select tags to help users find the {{ type }}. </gov-body>
+        <gov-body v-if="auth.isGlobalAdmin">
+          Select tags to help users find the {{ type }}.
+        </gov-body>
 
         <tag-input
           :service-tags="tags"


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2226/service-org-admins-can-t-update-services-which-have-been-tagged

- Removed tags from the service update request if they have not altered. This was preventing org and service admins, who are not allowed to alter tags, from submitting the update request

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
