### PR TITLE
Added homepage flag to persona update order

### DIFF
--- a/src/views/admin/index/collections/Personas.vue
+++ b/src/views/admin/index/collections/Personas.vue
@@ -94,6 +94,7 @@ export default {
         subtitle: collection.subtitle,
         order: collection.order,
         enabled: collection.enabled,
+        homepage: collection.homepage,
         sideboxes: collection.sideboxes,
         category_taxonomies: collection.category_taxonomies.map(
           taxonomy => taxonomy.id

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -127,6 +127,9 @@ export default {
     enabled: {
       required: true,
     },
+    homepage: {
+      required: true,
+    },
     sideboxes: {
       required: true,
     },


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2274/personas-no-longer-moving-on-homepage

- Homepage flag was missing from persona update order request. Added homepage flag.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
