### PR TITLE
Changed 3 refs to Help Yourself Sutton to Sutton Information Hub

### DIFF
--- a/src/views/services/forms/AdditionalInfoTab.vue
+++ b/src/views/services/forms/AdditionalInfoTab.vue
@@ -168,8 +168,8 @@
       <gov-grid-column width="one-half">
         <gov-body>
           Please provide your {{ type }}’s public-facing contact details. These
-          will be displayed on your {{ type }}’s page on the Help Yourself
-          Sutton website.
+          will be displayed on your {{ type }}’s page on the Sutton Information
+          Hub website.
         </gov-body>
 
         <gov-section-break size="l" />

--- a/src/views/services/forms/ReferralTab.vue
+++ b/src/views/services/forms/ReferralTab.vue
@@ -4,8 +4,8 @@
     <gov-grid-row>
       <gov-grid-column width="one-half">
         <gov-body>
-          Your {{ type }} can be set up to accept referrals through Help
-          Yourself Sutton. These referrals directly connect your {{ type }} to
+          Your {{ type }} can be set up to accept referrals through Sutton
+          Information Hub. These referrals directly connect your {{ type }} to
           residents.
         </gov-body>
         <gov-body>

--- a/src/views/users/Create.vue
+++ b/src/views/users/Create.vue
@@ -11,9 +11,9 @@
           <gov-heading size="m">Add user</gov-heading>
 
           <gov-body
-            >Create users to be able to acces the back-end of the Help Yourself
-            Sutton service (deciding their permissions in what they have access
-            to)</gov-body
+            >Create users to be able to acces the back-end of the Sutton
+            Information Hub service (deciding their permissions in what they
+            have access to)</gov-body
           >
 
           <user-form


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2565/reference-to-old-site-name-in-admin-ui

- Changed 3 refs to 'Help Yourself Sutton' to 'Sutton Information Hub'

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
